### PR TITLE
Import Set to ensure it's present when using it

### DIFF
--- a/lib/gdpr_exporter.rb
+++ b/lib/gdpr_exporter.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "gdpr_exporter/version"
-require 'csv'
+require "csv"
+require "set"
 
 module GdprExporter
     # Stores all the classes that have been tagged for gdpr collection


### PR DESCRIPTION
I'm upgrading an app on Rails 6.0 and this `Set` is not present when loading my model. I get the error:

```
NameError:
  uninitialized constant GdprExporter::Set
```
